### PR TITLE
TranslatorModal customTo 的 default value 預設套用 settings，避免非 zh-Hans 使用者每次都要手動選取

### DIFF
--- a/main.js
+++ b/main.js
@@ -2777,14 +2777,17 @@ var TranslatorModal = class extends import_obsidian3.Modal {
         containerEl.empty();
         switch (key) {
           case "youdaoEnable": {
+            this.customTo[type] = this.settings.yTo;
             this.youdaoTranslateHandler(containerEl);
             break;
           }
           case "microsoftEnable": {
+            this.customTo[type] = this.settings.mTo;
             this.microsoftTranslateHandler(containerEl);
             break;
           }
           case "baiduEnable": {
+            this.customTo[type] = this.settings.bTo;
             this.baiduTranslateHandler(containerEl);
             break;
           }


### PR DESCRIPTION
你好，感謝你寫了一個這麼有用的 plugin。
不過我在使用時發現，使用快捷鍵叫出來的 Translator 窗口預設一律是 zh-Hans，由於其他使用者可能的慣用語言不一致，想像上應該預設套用 settings 所填寫的 To 值比較合理，再麻煩了！